### PR TITLE
fix: make timestamp toggle text dynamic in command list

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -448,7 +448,7 @@ export function Session() {
       },
     },
     {
-      title: "Toggle timestamps",
+      title: showTimestamps() ? "Hide timestamps" : "Show timestamps",
       value: "session.toggle.timestamps",
       category: "Session",
       onSelect: (dialog) => {


### PR DESCRIPTION
DUMMY PR

Change 'Toggle timestamps' to dynamically show 'Show timestamps' or 'Hide timestamps' based on current state, matching the behavior of thinking blocks and tool details toggles.

Fixes #5106