### PR TITLE
Add copy-to-clipboard functionality for assistant message parts

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1203,6 +1203,7 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
 function TextPart(props: { last: boolean; part: TextPart; message: AssistantMessage }) {
   const ctx = use()
   const { theme, syntax } = useTheme()
+  const [hover, setHover] = createSignal(false)
   return (
     <Show when={props.part.text.trim()}>
       <box
@@ -1210,6 +1211,9 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
         paddingLeft={3}
         marginTop={1}
         flexShrink={0}
+        backgroundColor={hover() ? theme.backgroundElement : theme.background}
+        onMouseOver={() => setHover(true)}
+        onMouseOut={() => setHover(false)}
         onMouseUp={() => ctx.copyToClipboard(props.part.text.trim())}
       >
         <code
@@ -1234,6 +1238,7 @@ function ToolPart(props: { last: boolean; part: ToolPart; message: AssistantMess
   const { showDetails } = ctx
   const sync = useSync()
   const [margin, setMargin] = createSignal(0)
+  const [hover, setHover] = createSignal(false)
 
   function getToolOutput(): string | undefined {
     if (props.part.state.status === "completed") {
@@ -1272,18 +1277,21 @@ function ToolPart(props: { last: boolean; part: ToolPart; message: AssistantMess
             paddingLeft: 2,
             marginTop: 1,
             gap: 1,
-            backgroundColor: theme.backgroundPanel,
+            backgroundColor: hover() ? theme.backgroundElement : theme.backgroundPanel,
             customBorderChars: SplitBorder.customBorderChars,
             borderColor: permissionIndex === 0 ? theme.warning : theme.background,
           }
         : {
             paddingLeft: 3,
+            backgroundColor: hover() ? theme.backgroundElement : theme.background,
           }
 
     return (
       <box
         marginTop={margin()}
         {...style}
+        onMouseOver={() => setHover(true)}
+        onMouseOut={() => setHover(false)}
         onMouseUp={() => {
           const output = getToolOutput()
           if (output) ctx.copyToClipboard(output)

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -87,6 +87,7 @@ const context = createContext<{
   showDetails: () => boolean
   diffWrapMode: () => "word" | "none"
   sync: ReturnType<typeof useSync>
+  copyToClipboard: (text: string) => Promise<boolean>
 }>()
 
 function use() {
@@ -817,6 +818,16 @@ export function Session() {
   // snap to bottom when session changes
   createEffect(on(() => route.sessionID, toBottom))
 
+  async function copyToClipboard(text: string): Promise<boolean> {
+    if (renderer.getSelection()?.getSelectedText()) return false
+    await Clipboard.copy(text)
+    toast.show({
+      message: "Copied to clipboard",
+      variant: "success",
+    })
+    return true
+  }
+
   return (
     <context.Provider
       value={{
@@ -830,6 +841,7 @@ export function Session() {
         showDetails,
         diffWrapMode,
         sync,
+        copyToClipboard,
       }}
     >
       <box flexDirection="row">
@@ -1193,7 +1205,13 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
   const { theme, syntax } = useTheme()
   return (
     <Show when={props.part.text.trim()}>
-      <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
+      <box
+        id={"text-" + props.part.id}
+        paddingLeft={3}
+        marginTop={1}
+        flexShrink={0}
+        onMouseUp={() => ctx.copyToClipboard(props.part.text.trim())}
+      >
         <code
           filetype="markdown"
           drawUnstyledText={false}
@@ -1212,9 +1230,18 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
 
 function ToolPart(props: { last: boolean; part: ToolPart; message: AssistantMessage }) {
   const { theme } = useTheme()
-  const { showDetails } = use()
+  const ctx = use()
+  const { showDetails } = ctx
   const sync = useSync()
   const [margin, setMargin] = createSignal(0)
+
+  function getToolOutput(): string | undefined {
+    if (props.part.state.status === "completed") {
+      return props.part.state.output
+    }
+    return undefined
+  }
+
   const component = createMemo(() => {
     // Hide tool if showDetails is false and tool completed successfully
     // But always show if there's an error or permission is required
@@ -1257,6 +1284,10 @@ function ToolPart(props: { last: boolean; part: ToolPart; message: AssistantMess
       <box
         marginTop={margin()}
         {...style}
+        onMouseUp={() => {
+          const output = getToolOutput()
+          if (output) ctx.copyToClipboard(output)
+        }}
         renderBefore={function () {
           const el = this as BoxRenderable
           const parent = el.parent


### PR DESCRIPTION
DUMMY PR, IGNORE. 

Implements feature requested in issue #5641. Users can now click on:
- Text parts (code snippets, markdown content)
- Tool parts (command outputs, file contents)

Clicking copies the content to clipboard and shows a success toast. Text selection (click+drag) continues to work as before - if text is selected, the copy action is skipped to preserve existing behavior.

Changes:
- Extended session context with copyToClipboard helper function
- Added onMouseUp handlers to TextPart and ToolPart components
- Helper checks for text selection, copies to clipboard, and shows toast
- Tool parts only copy when completed with output available