### PR TITLE
feat: add config option to disable sidebar overlay mode

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -138,7 +138,10 @@ export function Session() {
     if (sidebar() === "auto" && wide()) return true
     return false
   })
-  const sidebarOverlay = createMemo(() => sidebarVisible() && !wide())
+  const sidebarOverlay = createMemo(() => {
+    if (sync.data.config.tui?.sidebar_overlay === false) return false
+    return sidebarVisible() && !wide()
+  })
   const contentWidth = createMemo(() => dimensions().width - (sidebarVisible() && !sidebarOverlay() ? 42 : 0) - 4)
 
   const scrollAcceleration = createMemo(() => {

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -585,6 +585,10 @@ export namespace Config {
       .enum(["auto", "stacked"])
       .optional()
       .describe("Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column"),
+    sidebar_overlay: z
+      .boolean()
+      .optional()
+      .describe("Enable sidebar overlay mode on narrow screens (default: true). Set to false to always show sidebar side-by-side with content"),
   })
 
   export const Layout = z.enum(["auto", "stretch"]).meta({


### PR DESCRIPTION
DUMMY PR, IGNORE.

- Add tui.sidebar_overlay config option (default: true)
- When set to false, sidebar always renders side-by-side with content
- Prevents dimming overlay behavior for users who prefer persistent side-by-side layout
- Addresses user preference for no dimming on narrow screens