### PR TITLE
fix: don't update session timestamp for metadata-only changes

### DIFF
--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -281,7 +281,7 @@ export const SessionRoutes = lazy(() =>
             session.title = updates.title
           }
           if (updates.time?.archived !== undefined) session.time.archived = updates.time.archived
-        })
+        }, { touch: false })
 
         return c.json(updatedSession)
       },

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -259,7 +259,7 @@ export namespace Session {
       draft.share = {
         url: share.url,
       }
-    })
+    }, { touch: false })
     return share
   })
 
@@ -269,14 +269,16 @@ export namespace Session {
     await ShareNext.remove(id)
     await update(id, (draft) => {
       draft.share = undefined
-    })
+    }, { touch: false })
   })
 
-  export async function update(id: string, editor: (session: Info) => void) {
+  export async function update(id: string, editor: (session: Info) => void, options?: { touch?: boolean }) {
     const project = Instance.project
     const result = await Storage.update<Info>(["session", project.id, id], (draft) => {
       editor(draft)
-      draft.time.updated = Date.now()
+      if (options?.touch !== false) {
+        draft.time.updated = Date.now()
+      }
     })
     Bus.publish(Event.Updated, {
       info: result,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1800,6 +1800,6 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
         const title = cleaned.length > 100 ? cleaned.substring(0, 97) + "..." : cleaned
         draft.title = title
-      })
+      }, { touch: false })
   }
 }


### PR DESCRIPTION
Adds optional { touch: false } parameter to Session.update() to skip automatic timestamp updates. Applied to:
- Title changes (rename)
- Archived changes
- Share/unshare
- Auto-generated titles

### What does this PR do?

### How did you verify your code works?
