### PR TITLE
Fix: Skills in plural 'skills/' directory not discovered (#9819)

### DIFF
--- a/packages/opencode/src/skill/skill.ts
+++ b/packages/opencode/src/skill/skill.ts
@@ -117,6 +117,7 @@ export namespace Skill {
         absolute: true,
         onlyFiles: true,
         followSymlinks: true,
+        dot: true,
       })) {
         await addSkill(match)
       }

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -95,6 +95,38 @@ description: Second test skill.
   })
 })
 
+test("discovers skills from .opencode/skills/ (plural) directory", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      const skillDir = path.join(dir, ".opencode", "skills", "plural-test-skill")
+      await Bun.write(
+        path.join(skillDir, "SKILL.md"),
+        `---
+name: plural-test-skill
+description: A test skill in the plural skills directory.
+---
+
+# Plural Test Skill
+
+Instructions here.
+`,
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const skills = await Skill.all()
+      expect(skills.length).toBe(1)
+      const testSkill = skills.find((s) => s.name === "plural-test-skill")
+      expect(testSkill).toBeDefined()
+      expect(testSkill!.location).toContain("skills/plural-test-skill/SKILL.md")
+    },
+  })
+})
+
 test("skips skills with missing frontmatter", async () => {
   await using tmp = await tmpdir({
     git: true,


### PR DESCRIPTION
Add missing 'dot: true' option to OpenCode skill glob scan to match behavior of other loaders (commands, agents, plugins).

This allows skills to be discovered from both .opencode/skill/ (singular) and .opencode/skills/ (plural) directories, matching documentation.

Also add test coverage for plural directory to prevent regression.

### What does this PR do?

### How did you verify your code works?
