### PR TITLE
Feat/sidebar header accent colors

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -99,7 +99,7 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
               </Show>
             </box>
             <box>
-              <text fg={theme.text}>
+              <text fg={theme.accent}>
                 <b>Context</b>
               </text>
               <text fg={theme.textMuted}>{context()?.tokens ?? 0} tokens</text>
@@ -116,7 +116,7 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                   <Show when={mcpEntries().length > 2}>
                     <text fg={theme.text}>{expanded.mcp ? "▼" : "▶"}</text>
                   </Show>
-                  <text fg={theme.text}>
+                  <text fg={theme.accent}>
                     <b>MCP</b>
                     <Show when={!expanded.mcp}>
                       <span style={{ fg: theme.textMuted }}>
@@ -176,7 +176,7 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                 <Show when={sync.data.lsp.length > 2}>
                   <text fg={theme.text}>{expanded.lsp ? "▼" : "▶"}</text>
                 </Show>
-                <text fg={theme.text}>
+                <text fg={theme.accent}>
                   <b>LSP</b>
                 </text>
               </box>
@@ -220,7 +220,7 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                   <Show when={todo().length > 2}>
                     <text fg={theme.text}>{expanded.todo ? "▼" : "▶"}</text>
                   </Show>
-                  <text fg={theme.text}>
+                  <text fg={theme.accent}>
                     <b>Todo</b>
                   </text>
                 </box>
@@ -239,7 +239,7 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                   <Show when={diff().length > 2}>
                     <text fg={theme.text}>{expanded.diff ? "▼" : "▶"}</text>
                   </Show>
-                  <text fg={theme.text}>
+                  <text fg={theme.accent}>
                     <b>Modified Files</b>
                   </text>
                 </box>


### PR DESCRIPTION
### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Makes the colour used for group titles in the sidebar more distinctive. 