### PR TITLE
fix(task): respect agent permission config for todowrite tool

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -64,9 +64,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
       if (!agent) throw new Error(`Unknown agent type: ${params.subagent_type} is not a valid agent type`)
 
       const hasTaskPermission = agent.permission.some((rule) => rule.permission === "task")
-      const hasTodoWritePermission = agent.permission.some(
-        (rule) => rule.permission === "todowrite" && rule.action === "allow",
-      )
+      const hasTodoWritePermission = agent.permission.some((rule) => rule.permission === "todowrite" && rule.action === "allow")
 
       const session = await iife(async () => {
         if (params.task_id) {

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -64,6 +64,12 @@ export const TaskTool = Tool.define("task", async (ctx) => {
       if (!agent) throw new Error(`Unknown agent type: ${params.subagent_type} is not a valid agent type`)
 
       const hasTaskPermission = agent.permission.some((rule) => rule.permission === "task")
+      const hasTodoWritePermission = agent.permission.some(
+        (rule) => rule.permission === "todowrite" && rule.action === "allow",
+      )
+      const hasTodoReadPermission = agent.permission.some(
+        (rule) => rule.permission === "todoread" && rule.action === "allow",
+      )
 
       const session = await iife(async () => {
         if (params.task_id) {
@@ -75,16 +81,24 @@ export const TaskTool = Tool.define("task", async (ctx) => {
           parentID: ctx.sessionID,
           title: params.description + ` (@${agent.name} subagent)`,
           permission: [
-            {
-              permission: "todowrite",
-              pattern: "*",
-              action: "deny",
-            },
-            {
-              permission: "todoread",
-              pattern: "*",
-              action: "deny",
-            },
+            ...(hasTodoWritePermission
+              ? []
+              : [
+                  {
+                    permission: "todowrite" as const,
+                    pattern: "*" as const,
+                    action: "deny" as const,
+                  },
+                ]),
+            ...(hasTodoReadPermission
+              ? []
+              : [
+                  {
+                    permission: "todoread" as const,
+                    pattern: "*" as const,
+                    action: "deny" as const,
+                  },
+                ]),
             ...(hasTaskPermission
               ? []
               : [
@@ -136,8 +150,8 @@ export const TaskTool = Tool.define("task", async (ctx) => {
         },
         agent: agent.name,
         tools: {
-          todowrite: false,
-          todoread: false,
+          ...(hasTodoWritePermission ? {} : { todowrite: false }),
+          ...(hasTodoReadPermission ? {} : { todoread: false }),
           ...(hasTaskPermission ? {} : { task: false }),
           ...Object.fromEntries((config.experimental?.primary_tools ?? []).map((t) => [t, false])),
         },

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -67,9 +67,6 @@ export const TaskTool = Tool.define("task", async (ctx) => {
       const hasTodoWritePermission = agent.permission.some(
         (rule) => rule.permission === "todowrite" && rule.action === "allow",
       )
-      const hasTodoReadPermission = agent.permission.some(
-        (rule) => rule.permission === "todoread" && rule.action === "allow",
-      )
 
       const session = await iife(async () => {
         if (params.task_id) {
@@ -86,15 +83,6 @@ export const TaskTool = Tool.define("task", async (ctx) => {
               : [
                   {
                     permission: "todowrite" as const,
-                    pattern: "*" as const,
-                    action: "deny" as const,
-                  },
-                ]),
-            ...(hasTodoReadPermission
-              ? []
-              : [
-                  {
-                    permission: "todoread" as const,
                     pattern: "*" as const,
                     action: "deny" as const,
                   },
@@ -151,7 +139,6 @@ export const TaskTool = Tool.define("task", async (ctx) => {
         agent: agent.name,
         tools: {
           ...(hasTodoWritePermission ? {} : { todowrite: false }),
-          ...(hasTodoReadPermission ? {} : { todoread: false }),
           ...(hasTaskPermission ? {} : { task: false }),
           ...Object.fromEntries((config.experimental?.primary_tools ?? []).map((t) => [t, false])),
         },


### PR DESCRIPTION
### Issue for this PR

Closes anomalyco#19101

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The todowrite tool was hardcoded as denied for all subagents, preventing users from enabling them via agent permission configuration even when explicitly allowed.

This change follows the existing pattern used for the task permission by checking if the agent has explicit allow rules for the todowrite tool before applying the default deny.

Changes:
- Add hasTodoWritePermission check
- Conditionally include deny rules in session creation
- Conditionally include false values in tools object

### How did you verify your code works?

Manual A/B testing, `bun test`, `bun typecheck`.

### Screenshots / recordings

No UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
