### PR TITLE
fix: replaceAll/e.diffs.map error in web

### DIFF
--- a/packages/app/src/components/file-tree.tsx
+++ b/packages/app/src/components/file-tree.tsx
@@ -213,11 +213,13 @@ export default function FileTree(props: {
   const level = props.level ?? 0
   const draggable = () => props.draggable ?? true
 
-  const key = (p: string) =>
-    file
-      .normalize(p)
+  const key = (p: string) => {
+    const normalized = file.normalize(p)
+    if (typeof normalized !== "string") return ""
+    return normalized
       .replace(/[\\/]+$/, "")
       .replaceAll("\\", "/")
+  }
   const chain = props._chain ? [...props._chain, key(props.path)] : [key(props.path)]
 
   const filter = createMemo(() => {

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -71,7 +71,7 @@ export function SessionSidePanel(props: {
     return "session.review.noChanges"
   })
 
-  const diffFiles = createMemo(() => diffs().map((d) => d.file))
+  const diffFiles = createMemo(() => diffs().filter((d) => d.file).map((d) => d.file))
   const kinds = createMemo(() => {
     const merge = (a: "add" | "del" | "mix" | undefined, b: "add" | "del" | "mix") => {
       if (!a) return b

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -74,7 +74,8 @@ export function SessionSidePanel(props: {
     return "session.review.noChanges"
   })
 
-  const diffFiles = createMemo(() => diffs().filter((d) => d.file).map((d) => d.file))
+  const diffFiles = createMemo(() =>
+    diffs().filter((d) => typeof d.file === "string").map((d) => d.file))
   const kinds = createMemo(() => {
     const merge = (a: "add" | "del" | "mix" | undefined, b: "add" | "del" | "mix") => {
       if (!a) return b
@@ -86,7 +87,7 @@ export function SessionSidePanel(props: {
 
     const out = new Map<string, "add" | "del" | "mix">()
     for (const diff of diffs()) {
-      if (!diff.file) continue
+      if (typeof diff.file !== "string") continue
       const file = normalize(diff.file)
       const kind = diff.status === "added" ? "add" : diff.status === "deleted" ? "del" : "mix"
 

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -83,6 +83,7 @@ export function SessionSidePanel(props: {
 
     const out = new Map<string, "add" | "del" | "mix">()
     for (const diff of diffs()) {
+      if (!diff.file) continue
       const file = normalize(diff.file)
       const kind = diff.status === "added" ? "add" : diff.status === "deleted" ? "del" : "mix"
 

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -55,7 +55,10 @@ export function SessionSidePanel(props: {
   const treeWidth = createMemo(() => (fileOpen() ? `${layout.fileTree.width()}px` : "0px"))
 
   const info = createMemo(() => (params.id ? sync.session.get(params.id) : undefined))
-  const diffs = createMemo(() => (params.id ? (sync.data.session_diff[params.id] ?? []) : []))
+  const diffs = createMemo(() => {
+    const raw = params.id ? sync.data.session_diff[params.id] : undefined
+    return Array.isArray(raw) ? raw : []
+  })
   const reviewCount = createMemo(() => Math.max(info()?.summary?.files ?? 0, diffs().length))
   const hasReview = createMemo(() => reviewCount() > 0)
   const diffsReady = createMemo(() => {

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -358,7 +358,7 @@ export namespace MessageV2 {
       .object({
         title: z.string().optional(),
         body: z.string().optional(),
-        diffs: Snapshot.FileDiff.array(),
+        diffs: Snapshot.FileDiff.array().optional(),
       })
       .optional(),
     agent: z.string(),

--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -127,6 +127,7 @@ export namespace SessionSummary {
     }),
     async (input) => {
       const diffs = await Storage.read<Snapshot.FileDiff[]>(["session_diff", input.sessionID]).catch(() => [])
+      if (!Array.isArray(diffs)) return []
       const next = diffs.map((item) => {
         const file = unquoteGitPath(item.file)
         if (file === item.file) return item

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -126,7 +126,7 @@ export type UserMessage = {
   summary?: {
     title?: string
     body?: string
-    diffs: Array<FileDiff>
+    diffs?: Array<FileDiff>
   }
   agent: string
   model: {

--- a/packages/ui/src/components/session-review.tsx
+++ b/packages/ui/src/components/session-review.tsx
@@ -85,7 +85,7 @@ export interface SessionReviewProps {
   classList?: Record<string, boolean | undefined>
   classes?: { root?: string; header?: string; container?: string }
   actions?: JSX.Element
-  diffs: ReviewDiff[]
+  diffs?: ReviewDiff[]
   onViewFile?: (file: string) => void
   readFile?: (path: string) => Promise<FileContent | undefined>
 }

--- a/packages/ui/src/components/session-review.tsx
+++ b/packages/ui/src/components/session-review.tsx
@@ -150,8 +150,8 @@ export const SessionReview = (props: SessionReviewProps) => {
   const opened = () => store.opened
 
   const open = () => props.open ?? store.open
-  const files = createMemo(() => props.diffs.map((diff) => diff.file))
-  const diffs = createMemo(() => new Map(props.diffs.map((diff) => [diff.file, diff] as const)))
+  const files = createMemo(() => (props.diffs ?? []).map((diff) => diff.file))
+  const diffs = createMemo(() => new Map((props.diffs ?? []).map((diff) => [diff.file, diff] as const)))
   const diffStyle = () => props.diffStyle ?? (props.split ? "split" : "unified")
   const hasDiffs = () => files().length > 0
 


### PR DESCRIPTION
### Issue for this PR

Closes anomalyco#19270 (unsuccessfully)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Attempts to resolve these two errors in web version (unsuccessfully, thus far).

<img width="823" height="249" alt="err2_replaceAll" src="https://github.com/user-attachments/assets/db0fc773-ebaf-48bd-bcca-6145b89e0f8d" />
<img width="780" height="261" alt="err1_e_diffs_map" src="https://github.com/user-attachments/assets/717db755-e6cd-40c7-8cfa-f1855b287046" />
