### PR TITLE
fix(opencode): embed customize-opencode skill file in compiled binary

### DIFF
--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -32,9 +32,8 @@ const SKILL_PATTERN = "**/SKILL.md"
 const CUSTOMIZE_OPENCODE_SKILL_NAME = "customize-opencode"
 const CUSTOMIZE_OPENCODE_SKILL_DESCRIPTION =
   "Use ONLY when the user is editing or creating opencode's own configuration: opencode.json, opencode.jsonc, files under .opencode/, or files under ~/.config/opencode/. Also use when creating or fixing opencode agents, subagents, skills, plugins, MCP servers, or permission rules. Do not use for the user's own application code, or for any project that is not configuring opencode itself."
-const CUSTOMIZE_OPENCODE_SKILL_BODY = await Bun.file(
-  new URL("../../../core/src/plugin/skill/customize-opencode.md", import.meta.url),
-).text()
+import customizeOpencodeSkillBody from "../../../../core/src/plugin/skill/customize-opencode.md" with { type: "file" }
+const CUSTOMIZE_OPENCODE_SKILL_BODY = await Bun.file(customizeOpencodeSkillBody).text()
 
 export const Info = Schema.Struct({
   name: Schema.String,


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

## Summary

The compiled Bun binary fails at startup with `ENOENT: no such file or directory, open '/core/src/plugin/skill/customize-opencode.md'` because `import.meta.url` resolves to a bunfs path inside the compiled binary, making the relative `new URL("../../../core/...", import.meta.url)` path invalid.

This affects `bun run build --single` (and all cross-compilation targets). The smoke test catches it because the module-level `await Bun.file(...)` runs on import, before `--version` even executes.

## Fix

Replace the runtime `new URL(..., import.meta.url)` resolution with Bun's `import ... with { type: "file" }` syntax, which embeds the file into the compiled binary at build time.

## Integration merge notes
- No new dependencies
- Works identically in both `bun dev` and compiled binary modes
- The `import ... with { type: "file" }` syntax is a Bun-native feature that bundles the referenced file into the binary

## Testing

- `bun typecheck` passes across all 22 packages
- `bun run build --single` succeeds with smoke test passing
- Binary correctly reports version via `--version`
